### PR TITLE
Added "it", "let", and "expect" snippets - updated "describe" snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The Chef Extension for Visual Studio Code offers rich language support for Chef 
  * env
  * erl_call
  * execute
+ * expect
  * file
  * freebsd_package
  * gem_package
@@ -53,6 +54,8 @@ The Chef Extension for Visual Studio Code offers rich language support for Chef 
  * http_request
  * ifconfig
  * ips_package
+ * it
+ * let
  * link
  * log
  * macports_package

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -67,7 +67,7 @@
 	},
 	"describe": {
 		"prefix": "describe",
-		"body": "describe '${1:action}' do\r\n	let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }\r\n\r\n	it 'includes the `${2:$1}` recipe' do\r\n	expect(chef_run).to include_recipe('${3:$1}')\r\n	end\r\nend",
+		"body": "describe '${1:COOKBOOK::RECIPE}' do\r\n	let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }\r\n\r\n	it 'DESCRIPTION_HERE' do\r\n	expect(chef_run).to ACTION_RESOURCE('NAME')\r\n	end\r\nend",
 		"description": "A describe block for writing a unit test",
 		"scope": "source.ruby.chef"
 	},
@@ -119,6 +119,12 @@
 		"description": "Use the execute resource to execute a single command.",
 		"scope": "source.ruby.chef"
 	},
+	"expect": {
+		"prefix": "expect",
+		"body": "expect(chef_run).to ACTION_RESOURCE('NAME')\r\n",
+		"description": "Use the expect resource to run the unit test",
+		"scope": "source.ruby.chef"
+	},	
 	"file": {
 		"prefix": "file",
 		"body": "file '${1:/path/to/file}' do\r\n  content '${2:content}'\r\n  owner '${3:root}'\r\n  group '${4:$3}'\r\n  mode '${5:0755}'\r\n  action :${6:create}\r\nend\r\n",
@@ -173,6 +179,18 @@
 		"description": "Use the ips_package resource to manage packages for the Solaris 11 platform.",
 		"scope": "source.ruby.chef"
 	},
+	"it": {
+		"prefix": "it",
+		"body": "it '${1:DESCRIPTION_HERE}' do\r\n\r\nend",
+		"description": "Used in unit test to describe what the test will do",
+		"scope": "source.ruby.chef"
+	},	
+	"let": {
+		"prefix": "let",
+		"body": "let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }\r\n\r\n",
+		"description": "Create the ChefSpec::SoloRunner and do a mock chef_run with run_list indicaded by the describe resource.",
+		"scope": "source.ruby.chef"
+	},		
 	"link": {
 		"prefix": "link",
 		"body": "link '${1:source_path}' do\r\n  to '${2:target_path}'\r\n  link_type :${3:hard}\r\nend\r\n",

--- a/syntaxes/chef.plist
+++ b/syntaxes/chef.plist
@@ -37,7 +37,7 @@
 		<!-- Chef built-in Resources - https://docs.chef.io/resources.html -->
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\.)\b(apt_package|bash|batch|bff_package|breakpoint|chef_gem|chef_handler|cookbook_file|cron|csh|deploy|describe|directory|dpkg_package|dsc_resource|dsc_script|easy_install_package|env|erl_call|execute|file|freebsd_package|gem_package|git|group|homebrew_package|http_request|ifconfig|ips_package|link|log|macports_package|mdadm|mount|ohai|openbsd_package|package|pacman_package|paludis_package|perl|portage_package|powershell_script|python|reboot|registry_key|remote_directory|remote_file|route|rpm_package|ruby|ruby_block|script|service|smartos_package|solaris_package|subversion|template|user|windows_package|windows_service|yum_package)\b(?![?!])</string>
+			<string>(?&lt;!\.)\b(apt_package|bash|batch|bff_package|breakpoint|chef_gem|chef_handler|cookbook_file|cron|csh|deploy|describe|directory|dpkg_package|dsc_resource|dsc_script|easy_install_package|env|erl_call|execute|expect|file|freebsd_package|gem_package|git|group|homebrew_package|http_request|ifconfig|ips_package|it|let|link|log|macports_package|mdadm|mount|ohai|openbsd_package|package|pacman_package|paludis_package|perl|portage_package|powershell_script|python|reboot|registry_key|remote_directory|remote_file|route|rpm_package|ruby|ruby_block|script|service|smartos_package|solaris_package|subversion|template|user|windows_package|windows_service|yum_package)\b(?![?!])</string>
 			<key>name</key>
 			<string>keyword.other.special-method.ruby</string>
 		</dict>


### PR DESCRIPTION
Added "it", "let", and "expect" snippets
Describe snippet needed to be reworked to better explain what it was doing. Additionally I created a format that I'll follow where any text in upper case should be modified by the user. This formatting helps make a clear distinction between what one will typically update and what one would keep as boiler plate.