### PR TITLE
Clear diagnosticCollection on clean Foodcritic Run

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -187,6 +187,7 @@ function validateCookbooks(): void {
 			diagnosticCollectionFoodcritic.set(arr);
 		} else {
 			console.log("Foodcritic executed but exited with status: " + foodcritic.status + foodcritic.stdout);
+			diagnosticCollectionFoodcritic.clear();
 		}
 	} catch (err) {
 		console.log(err);


### PR DESCRIPTION
When Foodcritic returns exit code 0 (clean run), execute diagnosticCollectionFoodcritic.clear
to clear out the 'Problems' window.

Mitigates #19.