### PR TITLE
Turned default string into bool

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -19,7 +19,7 @@
 	},
 	"apt_update": {
 		"prefix": "apt_update",
-		"body": "apt_update '${1:name}' do\r\n\tignore_failure '${2:true}'\r\n\taction :${3:update}\r\nend\r\n",
+		"body": "apt_update '${1:name}' do\r\n\tignore_failure ${2:true}\r\n\taction :${3:update}\r\nend\r\n",
 		"description": "Use the apt_update resource to manage APT cache for the Debian and Ubuntu platforms.",
 		"scope": "source.ruby.chef"
 	},


### PR DESCRIPTION
The default snippet passes in a string for the default value of the `ignore_failure` option for the apt-update resource. This actually needs to be a boolean and not a string.

**Error
<img width="729" alt="screen shot 2018-10-07 at 7 54 43 pm" src="https://user-images.githubusercontent.com/9658949/46588484-325bf980-ca6b-11e8-85ff-db6284d984a3.png">

**Before
<img width="177" alt="screen shot 2018-10-07 at 2 56 12 pm" src="https://user-images.githubusercontent.com/9658949/46588487-39830780-ca6b-11e8-8ebc-dc6b7a6e722e.png">

**After
<img width="189" alt="screen shot 2018-10-07 at 2 54 44 pm" src="https://user-images.githubusercontent.com/9658949/46588488-43a50600-ca6b-11e8-98a1-63b61a7be8f2.png">
