### PR TITLE
removed single quotes around true in apt_update

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -19,7 +19,7 @@
 	},
 	"apt_update": {
 		"prefix": "apt_update",
-		"body": "apt_update '${1:name}' do\r\n\tignore_failure '${2:true}'\r\n\taction :${3:update}\r\nend\r\n",
+		"body": "apt_update '${1:name}' do\r\n\tignore_failure ${2:true}\r\n\taction :${3:update}\r\nend\r\n",
 		"description": "Use the apt_update resource to manage APT cache for the Debian and Ubuntu platforms.",
 		"scope": "source.ruby.chef"
 	},


### PR DESCRIPTION
in the apt_update resource there should be no single quotes around true
```
apt_update 'update_repo' do
  ignore_failure true
  action :update
end
```
the quotes result in the following error 
```
18:  apt_update 'update_repo' do
 19>>   ignore_failure 'true'
 20:    action :update
21: end
```

```
[2018-11-05T14:51:50+00:00] FATAL: Chef::Exceptions::ValidationFailed: Property ignore_failure must be one of: true, false, :quiet, "quiet"!  You passed "true".
```