### PR TITLE
Rename to Chef Infra Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chef Infra Extension for Visual Studio Code
 
-The Chef Extension for Visual Studio Code offers rich language support for Chef Infra DSL and snippets when using [Visual Studio Code](http://code.visualstudio.com).
+The Chef Infra Extension for Visual Studio Code offers rich language support for Chef Infra DSL and snippets when using [Visual Studio Code](http://code.visualstudio.com).
 
 ![install and demo](https://github.com/pendrica/vscode-chef/raw/master/images/vscode-chef-install.gif)
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.7.1",
   "publisher": "Pendrica",
   "icon": "images/chef-logo.png",
-  "displayName": "Chef Extension for Visual Studio Code",
+  "displayName": "Chef Infra Extension for Visual Studio Code",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -68,7 +68,7 @@
     ],
     "configuration": {
       "type": "object",
-      "title": "Chef Extension for Visual Studio Code configuration",
+      "title": "Chef Infra Extension for Visual Studio Code configuration",
       "properties": {
         "rubocop.enable": {
           "type": "boolean",


### PR DESCRIPTION
Match current marketing names

Signed-off-by: Tim Smith <tsmith@chef.io>