### PR TITLE
Remove foodcritic support now that it's EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,6 @@ The Chef Extension for Visual Studio Code offers rich language support for Chef 
  * If you do not have the ChefDK but do have Rubocop installed, you can set the executable path by setting ```{ "rubocop.path": "c:\\path\\to\\rubocop.bat"}``` in user/workspace settings).
  * To override the config file used by Rubocop/Cookstyle, use the ```{ "rubocop.configFile": "path/to/config.yml" }``` in user/workspace settings.
 
-#### Foodcritic analysis (experimental):
-
- * Disabled by default (enable by adding ```{ "foodcritic.enable": true }``` in user/workspace settings)
- * When Ruby files are saved, the entire repo will be enumerated for cookbooks and Foodcritic run against each one.
- * If you have the [ChefDK](http://downloads.chef.io/chef-dk) installed, Foodcritic should "just work" on Windows, Mac OS X and Linux (Ubuntu)
- * If you do not have the ChefDK but do have Foodcritic installed, you can set the executable path by setting ```{ "foodcritic.path": "c:\\path\\to\\foodcritic.bat"}``` in user/workspace settings).
-
 #### Snippet support (with tabbing) for all Chef Infra built-in Resources:
 
  * apt_package

--- a/extension.ts
+++ b/extension.ts
@@ -5,18 +5,14 @@ import path = require("path");
 import vscode = require("vscode");
 
 let diagnosticCollectionRubocop: vscode.DiagnosticCollection;
-let diagnosticCollectionFoodcritic: vscode.DiagnosticCollection;
 let config: vscode.WorkspaceConfiguration;
 let rubocopPath: string;
 let rubocopConfigFile: string;
-let foodcriticPath: string;
 let cookbookPaths: Array<string> = [];
 
 export function activate(context: vscode.ExtensionContext): void {
 	diagnosticCollectionRubocop = vscode.languages.createDiagnosticCollection("rubocop");
-	diagnosticCollectionFoodcritic = vscode.languages.createDiagnosticCollection("foodcritic");
 	context.subscriptions.push(diagnosticCollectionRubocop);
-	context.subscriptions.push(diagnosticCollectionFoodcritic);
 
 	if (vscode.workspace.getConfiguration("rubocop").path === "") {
 		if (process.platform === "win32") {
@@ -40,23 +36,6 @@ export function activate(context: vscode.ExtensionContext): void {
 		validateWorkspace();
 		context.subscriptions.push(startLintingOnSaveWatcher());
 		context.subscriptions.push(startLintingOnConfigurationChangeWatcher());
-	}
-
-	if (vscode.workspace.getConfiguration("foodcritic").path === "") {
-		if (process.platform === "win32") {
-			foodcriticPath = "C:\\opscode\\chefdk\\embedded\\bin\\foodcritic.bat";
-		} else {
-			foodcriticPath = "/opt/chefdk/embedded/bin/foodcritic";
-		}
-	} else {
-		foodcriticPath = vscode.workspace.getConfiguration("foodcritic").path;
-		console.log("Using custom Foodcritic path: " + foodcriticPath);
-	}
-
-	if (vscode.workspace.getConfiguration("foodcritic").enable) {
-		recalculateValidCookbookPaths();
-		context.subscriptions.push(startCookbookAnalysisOnSaveWatcher());
-		context.subscriptions.push(startCookbookAnalysisOnConfigurationChangeWatcher());
 	}
 }
 
@@ -146,62 +125,6 @@ function startLintingOnConfigurationChangeWatcher():any {
 	return vscode.workspace.onDidChangeConfiguration(params => {
 		console.log("Workspace configuration changed, validating workspace.");
 		validateWorkspace();
-	});
-}
-
-function validateCookbooks(): void {
-	console.log("in validate cookbooks");
-	if (cookbookPaths.length === 0) { return; }
-	try {
-		let spawn = require("child_process").spawnSync;
-		cookbookPaths[cookbookPaths.length] = "--no-progress";
-		let foodcritic = spawn(foodcriticPath, cookbookPaths, { cwd: vscode.workspace.rootPath, encoding: "utf8" });
-		if (foodcritic.status > 0) {
-			let foodcriticOutput = foodcritic.stdout.trim().split("\n");
-			let arr = [];
-			for (var r = 0; r < foodcriticOutput.length; r++) {
-				if (foodcriticOutput[r] !== "") {
-					let diagnostics: vscode.Diagnostic[] = [];
-					let fcId = foodcriticOutput[r].split(":")[0].trim();
-					let fcDescription = foodcriticOutput[r].split(":")[1].trim();
-					let fcPath = foodcriticOutput[r].split(":")[2].trim();
-					let lineNumber = parseInt(foodcriticOutput[r].split(":")[3].trim(), 10) - 1;
-					let uri: vscode.Uri = vscode.Uri.file((path.join(vscode.workspace.rootPath, fcPath)));
-					let diagRange = new vscode.Range(lineNumber, 0, lineNumber, 0);
-					let diagnostic = new vscode.Diagnostic(diagRange, fcId + ": " + fcDescription, vscode.DiagnosticSeverity.Warning);
-					let found: boolean = false;
-					diagnostics.push(diagnostic);
-					for (var l = 0; l < arr.length; l++) {
-						if (arr[l][0].path === uri.path) {
-							arr[l][1].push(diagnostic);
-							found = true;
-						}
-					}
-					if (!found) {
-						arr.push([uri, diagnostics]);
-					}
-				}
-			}
-
-			diagnosticCollectionFoodcritic.clear();
-			diagnosticCollectionFoodcritic.set(arr);
-		} else {
-			console.log("Foodcritic executed but exited with status: " + foodcritic.status + foodcritic.stdout);
-			diagnosticCollectionFoodcritic.clear();
-		}
-	} catch (err) {
-		console.log(err);
-	}
-	return;
-}
-
-function startCookbookAnalysisOnSaveWatcher():any {
-	return vscode.workspace.onDidSaveTextDocument(document => {
-		console.log("onDidSaveTextDocument event received (foodcritic).");
-		if (document.languageId !== "ruby") {
-			return;
-		}
-		validateCookbooks();
 	});
 }
 

--- a/package.json
+++ b/package.json
@@ -84,16 +84,6 @@
           "type": "string",
           "default": "",
           "description": "Path to a Rubocop config file (e.g. .rubocop_shared.yml) - relative paths resolve inside the workspace."
-        },
-        "foodcritic.enable": {
-          "type": "boolean",
-          "default": false,
-          "description": "Control whether Foodcritic analysis is enabled or not."
-        },
-        "foodcritic.path": {
-          "type": "string",
-          "default": "",
-          "description": "Full path to Foodcritic, only change this if you have the ChefDK installed in a non-standard location."
         }
       }
     }


### PR DESCRIPTION
Foodcritic has been replaced by Cookstyle now that Cookstyle handles
both Ruby and Chef linting. This speeds up this extension as now we only
need to run a single linting on code changes.

Signed-off-by: Tim Smith <tsmith@chef.io>