### PR TITLE
Update the extension category name

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "vscode.ruby"
   ],
   "categories": [
-    "Languages",
+    "Programming Languages",
     "Snippets",
     "Linters"
   ],


### PR DESCRIPTION
Languages has been renamed to Programming Languages. This fixes the linting error.

Signed-off-by: Tim Smith <tsmith@chef.io>